### PR TITLE
コマンド関連クラスの作成

### DIFF
--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -24,6 +24,9 @@ package app.cmds {
         public function executeAsBattleCommand():void {
 
         }
+        
+        public function cancel():void{
+        }
 
     }
 

--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -1,13 +1,17 @@
 package app.cmds {
 
+    import app.charas.Character;
+
     /**
      * ...
      * @author
      */
     public class AttackCommand implements IBattleCommand {
 
-        public function AttackCommand() {
+        private var owner:Character;
 
+        public function AttackCommand(owner:Character) {
+            this.owner = owner;
         }
 
 

--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -1,0 +1,26 @@
+package app.cmds {
+
+    /**
+     * ...
+     * @author
+     */
+    public class AttackCommand implements IBattleCommand {
+
+        public function AttackCommand() {
+
+        }
+
+
+        /* INTERFACE app.cmds.IBattleCommand */
+
+        public function get DisplayName():String {
+            return "攻撃";
+        }
+
+        public function executeAsBattleCommand():void {
+
+        }
+
+    }
+
+}

--- a/src/app/cmds/CommandsStack.as
+++ b/src/app/cmds/CommandsStack.as
@@ -1,0 +1,18 @@
+package app.cmds {
+
+    public class CommandsStack {
+
+        private var commands:Vector.<Vector.<IBattleCommand>> = new Vector.<Vector.<IBattleCommand>>();
+
+        public function CommandsStack() {
+        }
+
+        public function stack(vec:Vector.<IBattleCommand>):void {
+            commands.push(vec);
+        }
+
+        public function get TopCommands():Vector.<IBattleCommand> {
+            return commands[commands.length - 1];
+        }
+    }
+}

--- a/src/app/cmds/IBattleCommand.as
+++ b/src/app/cmds/IBattleCommand.as
@@ -7,6 +7,7 @@ package app.cmds {
     public interface IBattleCommand {
         function get DisplayName():String;
         function executeAsBattleCommand():void;
+        function cancel():void;
     }
 
 }

--- a/src/app/cmds/IBattleCommand.as
+++ b/src/app/cmds/IBattleCommand.as
@@ -1,0 +1,12 @@
+package app.cmds {
+
+    /**
+     * ...
+     * @author
+     */
+    public interface IBattleCommand {
+        function get DisplayName():String;
+        function executeAsBattleCommand():void;
+    }
+
+}

--- a/src/app/cmds/ItemCommand.as
+++ b/src/app/cmds/ItemCommand.as
@@ -25,6 +25,8 @@ package app.cmds {
 
         }
 
+        public function cancel():void {
+        }
     }
 
 }

--- a/src/app/cmds/ItemCommand.as
+++ b/src/app/cmds/ItemCommand.as
@@ -1,0 +1,26 @@
+package app.cmds {
+
+    /**
+     * ...
+     * @author
+     */
+    public class ItemCommand implements IBattleCommand {
+
+        public function ItemCommand() {
+
+        }
+
+
+        /* INTERFACE app.cmds.IBattleCommand */
+
+        public function get DisplayName():String {
+            return "アイテム";
+        }
+
+        public function executeAsBattleCommand():void {
+
+        }
+
+    }
+
+}

--- a/src/app/cmds/ItemCommand.as
+++ b/src/app/cmds/ItemCommand.as
@@ -1,13 +1,17 @@
 package app.cmds {
 
+    import app.charas.Character;
+
     /**
      * ...
      * @author
      */
     public class ItemCommand implements IBattleCommand {
 
-        public function ItemCommand() {
+        private var owner:Character;
 
+        public function ItemCommand(owner:Character) {
+            this.owner = owner;
         }
 
 

--- a/src/app/cmds/SkillCommand.as
+++ b/src/app/cmds/SkillCommand.as
@@ -1,0 +1,26 @@
+package app.cmds {
+
+    /**
+     * ...
+     * @author
+     */
+    public class SkillCommand implements IBattleCommand {
+
+        public function SkillCommand() {
+
+        }
+
+
+        /* INTERFACE app.cmds.IBattleCommand */
+
+        public function get DisplayName():String {
+            return "スキル";
+        }
+
+        public function executeAsBattleCommand():void {
+
+        }
+
+    }
+
+}

--- a/src/app/cmds/SkillCommand.as
+++ b/src/app/cmds/SkillCommand.as
@@ -25,6 +25,8 @@ package app.cmds {
 
         }
 
+        public function cancel():void {
+        }
     }
 
 }

--- a/src/app/cmds/SkillCommand.as
+++ b/src/app/cmds/SkillCommand.as
@@ -1,13 +1,17 @@
 package app.cmds {
 
+    import app.charas.Character;
+
     /**
      * ...
      * @author
      */
     public class SkillCommand implements IBattleCommand {
 
-        public function SkillCommand() {
+        private var owner:Character
 
+        public function SkillCommand(owner:Character) {
+            this.owner = owner;
         }
 
 

--- a/src/tests/Tester.as
+++ b/src/tests/Tester.as
@@ -1,6 +1,7 @@
 package tests {
 
     import tests.charas.*;
+    import tests.cmds.*;
 
     /**
      * ...
@@ -14,6 +15,11 @@ package tests {
 
             new TestAbilityInteger();
             new TestCharacter();
+
+            new TestAttackCommand();
+            new TestSkillCommand();
+            new TestItemCommand();
+            new TestCommandStack();
 
             trace("[Tester]" + " " + Assert.TestCounter + " 回のテストを完了しました");
         }

--- a/src/tests/cmds/TestAttackCommand.as
+++ b/src/tests/cmds/TestAttackCommand.as
@@ -1,0 +1,24 @@
+package tests.cmds {
+    import app.cmds.AttackCommand;
+    import app.charas.CharacterBuilder;
+    import app.charas.Character;
+    import app.charas.Ability;
+
+    /**
+     * ...
+     * @author
+     */
+    public class TestAttackCommand {
+
+        public function TestAttackCommand() {
+            test();
+        }
+
+        private function test():void {
+            var character:Character = new CharacterBuilder().build();
+            var attackCommand:AttackCommand = new AttackCommand(character);
+        }
+
+    }
+
+}

--- a/src/tests/cmds/TestCommandStack.as
+++ b/src/tests/cmds/TestCommandStack.as
@@ -1,0 +1,35 @@
+package tests.cmds {
+
+    import app.cmds.CommandsStack;
+    import app.cmds.IBattleCommand;
+    import app.cmds.AttackCommand;
+    import tests.Assert;
+    import app.charas.CharacterBuilder;
+    import app.charas.Character;
+
+    public class TestCommandStack {
+        public function TestCommandStack() {
+            test();
+        }
+
+        private function test():void {
+
+            var character:Character = new CharacterBuilder().build();
+
+            var commandStack:CommandsStack = new CommandsStack();
+            var commands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+            var commandA:IBattleCommand = new AttackCommand(character);
+            commands.push(commandA);
+            commandStack.stack(commands);
+
+            Assert.areEqual(commands, commandStack.TopCommands);
+
+            var commandsB:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+            var commandB:IBattleCommand = new AttackCommand(character);
+            commandsB.push(commandB);
+            commandStack.stack(commandsB);
+
+            Assert.areEqual(commandsB, commandStack.TopCommands);
+        }
+    }
+}

--- a/src/tests/cmds/TestItemCommand.as
+++ b/src/tests/cmds/TestItemCommand.as
@@ -1,0 +1,24 @@
+package tests.cmds {
+
+    import app.cmds.ItemCommand;
+    import app.charas.Character;
+    import app.charas.CharacterBuilder;
+
+    /**
+     * ...
+     * @author
+     */
+    public class TestItemCommand {
+
+        public function TestItemCommand() {
+            test();
+        }
+
+        private function test():void {
+            var character:Character = new CharacterBuilder().build();
+            var itemCommand:ItemCommand = new ItemCommand(character);
+        }
+
+    }
+
+}

--- a/src/tests/cmds/TestSkillCommand.as
+++ b/src/tests/cmds/TestSkillCommand.as
@@ -1,0 +1,23 @@
+package tests.cmds {
+    import app.cmds.SkillCommand;
+    import app.charas.CharacterBuilder;
+    import app.charas.Character;
+
+    /**
+     * ...
+     * @author
+     */
+    public class TestSkillCommand {
+
+        public function TestSkillCommand() {
+            test();
+        }
+
+        private function test():void {
+            var character:Character = new CharacterBuilder().build();
+            var skillCommand:SkillCommand = new SkillCommand(character);
+        }
+
+    }
+
+}


### PR DESCRIPTION
- インターフェース追加 / 戦闘中のコマンドに実装するインターフェースを追加
- クラス追加 / 戦闘時の攻撃コマンドを表すクラスを追加
- クラス追加 / 戦闘中のアイテム、スキルのコマンドを表すクラスを追加
- クラス追加 / 複数のコマンドベクターを管理するクラスを追加
- 仕様変更 / 各コマンドクラスのコンストラクタに引数を追加
- 機能追加 / IBattleCommand に cancel() を追加

close #3
