### PR TITLE
Action関連のクラスを作成する

### DIFF
--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -4,9 +4,10 @@ package app.charas {
      * ...
      * @author
      */
-    public class Character {
+    public class Character implements ITarget {
 
         private var name:String;
+        private var isFriend:Boolean = true;
 
         public function get Name():String {
             return name;
@@ -33,6 +34,18 @@ package app.charas {
             this.abilities = ability;
         }
 
+
+        public function get DisplayName():String {
+            return name;
+        }
+
+        public function get IsFriend():Boolean {
+            return isFriend;
+        }
+
+        public function get IsAlive():Boolean {
+            return (this.Abilities.HP.Currentry > 0);
+        }
     }
 
 }

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -1,5 +1,8 @@
 package app.charas {
 
+    import app.cmds.CommandsStack;
+    import app.cmds.IBattleCommand;
+
     /**
      * ...
      * @author
@@ -8,6 +11,8 @@ package app.charas {
 
         private var name:String;
         private var isFriend:Boolean = true;
+        private var commandStack:CommandsStack = new CommandsStack();
+        public var otherCharacters:Vector.<ITarget>;
 
         public function get Name():String {
             return name;
@@ -29,9 +34,10 @@ package app.charas {
             action = value;
         }
 
-        public function Character(name:String, ability:Ability) {
+        public function Character(name:String, ability:Ability, isFriend:Boolean = true) {
             this.name = name;
             this.abilities = ability;
+            this.isFriend = isFriend;
         }
 
 
@@ -45,6 +51,38 @@ package app.charas {
 
         public function get IsAlive():Boolean {
             return (this.Abilities.HP.Currentry > 0);
+        }
+
+        public function get Commands():CommandsStack {
+            return commandStack;
+        }
+
+        public function executeBattleCommand(commandIndex:int):void {
+            var selectedCommand:IBattleCommand = commandStack.TopCommands[commandIndex];
+            if (selectedCommand is IAction) {
+                // Skill or Item
+                Action = IAction(selectedCommand);
+                Action.Targets = getTargetables(Action.TargetRange);
+                var battleCommands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+                for each (var t:ITarget in Action.Targets) {
+                    battleCommands.push(IBattleCommand(t));
+                }
+            }
+
+            if (selectedCommand is ITarget) {
+                // selected target character
+
+            }
+            commandStack.TopCommands[commandIndex].executeAsBattleCommand();
+        }
+
+        private function getTargetables(targetableRange:String):Vector.<ITarget> {
+            var selectFriend:Boolean = Range.getAbsoluteSide(this, Range.RELATIVE_SINGLE_FRIEND)
+            var selected:Vector.<ITarget> = otherCharacters.filter(function(item:ITarget, i:int, v:*):Boolean {
+                return item.IsFriend == selectFriend;
+            });
+
+            return selected;
         }
     }
 

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -18,6 +18,16 @@ package app.charas {
             return abilities;
         }
 
+        private var action:IAction;
+
+        public function get Action():IAction {
+            return action;
+        }
+
+        public function set Action(value:IAction):void {
+            action = value;
+        }
+
         public function Character(name:String, ability:Ability) {
             this.name = name;
             this.abilities = ability;

--- a/src/app/charas/CharacterBuilder.as
+++ b/src/app/charas/CharacterBuilder.as
@@ -13,6 +13,7 @@ package app.charas {
         private var atk:int;
         private var gud:int;
         private var spd:int;
+        private var isFriend:Boolean;
 
         public function CharacterBuilder() {
 
@@ -27,8 +28,13 @@ package app.charas {
             var mspd:AbilityInteger = new AbilityInteger(0, spd);
             var ability:Ability = new Ability(mlevel, mhp, msp, matk, mgud, mspd);
 
-            var character:Character = new Character(characterName, ability);
+            var character:Character = new Character(characterName, ability, isFriend);
             return character;
+        }
+
+        public function setIsFriend(bool:Boolean):CharacterBuilder {
+            this.isFriend = bool;
+            return this;
         }
 
         public function setName(name:String):CharacterBuilder {

--- a/src/app/charas/IAction.as
+++ b/src/app/charas/IAction.as
@@ -2,5 +2,7 @@ package app.charas {
 
     public interface IAction {
         function act():void
+        function get Targets():Vector.<ITarget>;
+        function set Targets(value:Vector.<ITarget>):void;
     }
 }

--- a/src/app/charas/IAction.as
+++ b/src/app/charas/IAction.as
@@ -1,0 +1,6 @@
+package app.charas {
+
+    public interface IAction {
+        function act():void
+    }
+}

--- a/src/app/charas/IAction.as
+++ b/src/app/charas/IAction.as
@@ -4,5 +4,6 @@ package app.charas {
         function act():void
         function get Targets():Vector.<ITarget>;
         function set Targets(value:Vector.<ITarget>):void;
+        function get TargetRange():String;
     }
 }

--- a/src/app/charas/ITarget.as
+++ b/src/app/charas/ITarget.as
@@ -1,0 +1,8 @@
+package app.charas {
+
+    public interface ITarget {
+        function get DisplayName():String;
+        function get IsFriend():Boolean;
+        function get IsAlive():Boolean;
+    }
+}

--- a/src/app/charas/Item.as
+++ b/src/app/charas/Item.as
@@ -1,0 +1,43 @@
+package app.charas {
+
+    import app.cmds.IBattleCommand;
+
+    public class Item implements IBattleCommand, IAction {
+
+        private var displayName:String;
+        private var owner:Character;
+        private var targets:Vector.<ITarget> = new Vector.<ITarget>();
+        private var targetRange:String;
+
+        public function Item(owner:Character, itemName:String, targetRange:String) {
+            this.owner = owner;
+            displayName = itemName;
+            this.targetRange = targetRange;
+        }
+
+        public function act():void {
+        }
+
+        public function get Targets():Vector.<ITarget> {
+            return targets
+        }
+
+        public function set Targets(value:Vector.<ITarget>):void {
+            targets = value;
+        }
+
+        public function get TargetRange():String {
+            return targetRange;
+        }
+
+        public function get DisplayName():String {
+            return displayName;
+        }
+
+        public function executeAsBattleCommand():void {
+        }
+
+        public function cancel():void {
+        }
+    }
+}

--- a/src/app/charas/Item.as
+++ b/src/app/charas/Item.as
@@ -35,6 +35,7 @@ package app.charas {
         }
 
         public function executeAsBattleCommand():void {
+            owner.Action = this;
         }
 
         public function cancel():void {

--- a/src/app/charas/ItemBuilder.as
+++ b/src/app/charas/ItemBuilder.as
@@ -1,0 +1,59 @@
+package app.charas {
+
+    public class ItemBuilder {
+
+        private var itemName:String = "";
+        private var owner:Character;
+        private var targetRange:String;
+
+        public function ItemBuilder() {
+        }
+
+        public function setName(value:String):ItemBuilder {
+            itemName = value;
+            return this;
+        }
+
+        public function setOwner(value:Character):ItemBuilder {
+            owner = value;
+            return this;
+        }
+
+        public function setTargetRange(range:String):ItemBuilder {
+            targetRange = range;
+            return this;
+        }
+
+        /**
+         * 現在のフィールドの値を使用してアイテムオブジェクトを生成します。
+         * @param itemNumber 番号を指定した場合、owner 以外に関しては現在のビルダーのフィールドに依存しない値でアイテムを生成します。
+         * owner だけは必要になるので、値を入力してからこのメソッドを呼び出してください。
+         * 生成したアイテムに初期値のフィールドがあった場合はエラーを投げます。
+         * @return
+         */
+        public function build(itemNumber:int = -1):Item {
+            var resultItem:Item;
+            if (itemNumber < 0) {
+                resultItem = new Item(owner, itemName, targetRange);
+            } else {
+                if (itemNumber == 0) {
+                    resultItem = new Item(owner, "testItem0", Range.RELATIVE_SINGLE_ENEMY);
+                }
+
+                if (itemNumber == 1) {
+                    resultItem = new Item(owner, "testItem1", Range.RELATIVE_SINGLE_FRIEND);
+                }
+
+                if (itemNumber == 2) {
+                    resultItem = new Item(owner, "testItem2", Range.RELATIVE_ALL_ENEMY);
+                }
+
+                if (itemNumber == 3) {
+                    resultItem = new Item(owner, "testItem3", Range.RELATIVE_ALL_FRIEDN);
+                }
+            }
+
+            return resultItem;
+        }
+    }
+}

--- a/src/app/charas/Range.as
+++ b/src/app/charas/Range.as
@@ -6,5 +6,19 @@ package app.charas {
         public static const RELATIVE_ALL_FRIEDN:String = "relativeAllFriend";
         public static const RELATIVE_SINGLE_ENEMY:String = "relativeSingleEnemy";
         public static const RELATIVE_SINGLE_FRIEND:String = "relativeSingleFriend";
+
+        /**
+         * 引数に入力したキャラクターを基準とした場合の絶対範囲を取得します。
+         * @param character 基準となるキャラクターです。主にこのメソッドを呼び出すキャラクターをthisで入力します。
+         * @param range このクラスに定義されている定数のうち、ALL 以外のいずれかを入力します。
+         * @return 入力した相対範囲に該当する側を取得します。
+         */
+        public static function getAbsoluteSide(character:ITarget, range:String):Boolean {
+            if (character.IsFriend) {
+                return (range == RELATIVE_ALL_FRIEDN || range == RELATIVE_SINGLE_FRIEND);
+            } else {
+                return (range == RELATIVE_ALL_ENEMY || range == RELATIVE_SINGLE_ENEMY);
+            }
+        }
     }
 }

--- a/src/app/charas/Range.as
+++ b/src/app/charas/Range.as
@@ -1,0 +1,10 @@
+package app.charas {
+
+    public class Range {
+        public static const ALL:String = "all";
+        public static const RELATIVE_ALL_ENEMY:String = "relativeAllEnemy";
+        public static const RELATIVE_ALL_FRIEDN:String = "relativeAllFriend";
+        public static const RELATIVE_SINGLE_ENEMY:String = "relativeSingleEnemy";
+        public static const RELATIVE_SINGLE_FRIEND:String = "relativeSingleFriend";
+    }
+}

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -1,0 +1,34 @@
+package app.charas {
+
+    import app.cmds.IBattleCommand;
+
+    public class Skill implements IBattleCommand, IAction {
+
+        private var owner:Character;
+        private var displayName:String = "";
+        private var cost:int = 0;
+
+        public function Skill(owner:Character, skillName:String, cost:int) {
+            this.owner = owner;
+            displayName = skillName;
+            this.cost = cost;
+        }
+
+        public function get DisplayName():String {
+            return displayName;
+        }
+
+        public function get Cost():int {
+            return cost;
+        }
+
+        public function executeAsBattleCommand():void {
+        }
+
+        public function cancel():void {
+        }
+
+        public function act():void {
+        }
+    }
+}

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -27,6 +27,7 @@ package app.charas {
         }
 
         public function executeAsBattleCommand():void {
+            owner.Action = this;
         }
 
         public function cancel():void {

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -1,12 +1,14 @@
 package app.charas {
 
     import app.cmds.IBattleCommand;
+    import app.charas.ITarget;
 
     public class Skill implements IBattleCommand, IAction {
 
         private var owner:Character;
         private var displayName:String = "";
         private var cost:int = 0;
+        private var targets:Vector.<ITarget> = new Vector.<ITarget>();
 
         public function Skill(owner:Character, skillName:String, cost:int) {
             this.owner = owner;
@@ -29,6 +31,14 @@ package app.charas {
         }
 
         public function act():void {
+        }
+
+        public function get Targets():Vector.<ITarget> {
+            return targets;
+        }
+
+        public function set Targets(value:Vector.<ITarget>):void {
+            targets = value;
         }
     }
 }

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -9,11 +9,13 @@ package app.charas {
         private var displayName:String = "";
         private var cost:int = 0;
         private var targets:Vector.<ITarget> = new Vector.<ITarget>();
+        private var targetRange:String;
 
-        public function Skill(owner:Character, skillName:String, cost:int) {
+        public function Skill(owner:Character, skillName:String, cost:int, targetRange:String) {
             this.owner = owner;
             displayName = skillName;
             this.cost = cost;
+            this.targetRange = targetRange;
         }
 
         public function get DisplayName():String {
@@ -39,6 +41,10 @@ package app.charas {
 
         public function set Targets(value:Vector.<ITarget>):void {
             targets = value;
+        }
+
+        public function get TargetRange():String {
+            return targetRange;
         }
     }
 }

--- a/src/app/charas/SkillBuilder.as
+++ b/src/app/charas/SkillBuilder.as
@@ -5,13 +5,14 @@ package app.charas {
         private var skillName:String = "";
         private var cost:int = 0;
         private var owner:Character;
+        private var targetRange:String = Range.RELATIVE_SINGLE_ENEMY;
 
         public function SkillBuilder() {
 
         }
 
         public function build():Skill {
-            var skill:Skill = new Skill(owner, skillName, cost);
+            var skill:Skill = new Skill(owner, skillName, cost, targetRange);
             return skill;
         }
 
@@ -27,6 +28,11 @@ package app.charas {
 
         public function setOwner(owner:Character):SkillBuilder {
             this.owner = owner;
+            return this;
+        }
+
+        public function setTargetRange(targetRange:String):SkillBuilder {
+            this.targetRange = targetRange;
             return this;
         }
     }

--- a/src/app/charas/SkillBuilder.as
+++ b/src/app/charas/SkillBuilder.as
@@ -1,0 +1,33 @@
+package app.charas {
+
+    public class SkillBuilder {
+
+        private var skillName:String = "";
+        private var cost:int = 0;
+        private var owner:Character;
+
+        public function SkillBuilder() {
+
+        }
+
+        public function build():Skill {
+            var skill:Skill = new Skill(owner, skillName, cost);
+            return skill;
+        }
+
+        public function setName(skillName:String):SkillBuilder {
+            this.skillName = skillName;
+            return this;
+        }
+
+        public function setCost(cost:int):SkillBuilder {
+            this.cost = cost;
+            return this;
+        }
+
+        public function setOwner(owner:Character):SkillBuilder {
+            this.owner = owner;
+            return this;
+        }
+    }
+}

--- a/src/app/cmds/CommandsStack.as
+++ b/src/app/cmds/CommandsStack.as
@@ -12,7 +12,11 @@ package app.cmds {
         }
 
         public function get TopCommands():Vector.<IBattleCommand> {
-            return commands[commands.length - 1];
+            if (commands.length == 0) {
+                return new Vector.<IBattleCommand>();
+            } else {
+                return commands[commands.length - 1];
+            }
         }
     }
 }

--- a/src/tests/Assert.as
+++ b/src/tests/Assert.as
@@ -1,31 +1,37 @@
 package tests {
-	/**
-	 * ...
-	 * @author 
-	 */
-	public final class Assert {
-		
-		private static var testCounter:int;
-		
-		public function Assert() {
-			
-		}
-		
-		public static function areEqual(a:*, b:*):void{
-			if (a != b) throw Error(a + " != " + b);
-			testCounter++;
-		}
-		
-		public static function isTrue(value:Boolean):void{
-			if (!value) throw Error("value is false");
-			testCounter++;
-		}
 
-		public static function isFalse(value:Boolean):void{
-			if (value) throw Error("value is true");
-			testCounter++;
-		}
+    /**
+     * ...
+     * @author
+     */
+    public final class Assert {
 
-		public static function get TestCounter():int{ return testCounter; }
-	}
+        private static var testCounter:int;
+
+        public function Assert() {
+
+        }
+
+        public static function areEqual(a:*, b:*):void {
+            if (a != b)
+                throw Error(a + " != " + b);
+            testCounter++;
+        }
+
+        public static function isTrue(value:Boolean):void {
+            if (!value)
+                throw Error("value is false");
+            testCounter++;
+        }
+
+        public static function isFalse(value:Boolean):void {
+            if (value)
+                throw Error("value is true");
+            testCounter++;
+        }
+
+        public static function get TestCounter():int {
+            return testCounter;
+        }
+    }
 }

--- a/src/tests/Tester.as
+++ b/src/tests/Tester.as
@@ -20,6 +20,8 @@ package tests {
             new TestSkillCommand();
             new TestItemCommand();
             new TestCommandStack();
+            new TestSkill();
+            new TestItem();
 
             trace("[Tester]" + " " + Assert.TestCounter + " 回のテストを完了しました");
         }

--- a/src/tests/charas/TestCharacter.as
+++ b/src/tests/charas/TestCharacter.as
@@ -3,6 +3,8 @@ package tests.charas {
     import app.charas.CharacterBuilder;
     import app.charas.Ability;
     import tests.Assert;
+    import app.charas.ITarget;
+    import app.charas.Range;
 
     /**
      * ...
@@ -23,9 +25,29 @@ package tests.charas {
             characterBuilder.setAtk(3);
             characterBuilder.setGud(3);
             characterBuilder.setSp(2);
+            characterBuilder.setIsFriend(true);
 
             var testCharacter:Character = characterBuilder.build();
             Assert.areEqual(testCharacter.Name, "testCharacter");
+            Assert.areEqual(testCharacter.IsFriend, true);
+
+            characterBuilder.setName("testCharacter2");
+            var testCharacter2:Character = characterBuilder.build();
+
+            characterBuilder.setName("testCharacter3");
+            var testCharacter3:Character = characterBuilder.build();
+
+            characterBuilder.setIsFriend(false);
+            characterBuilder.setName("enemy0");
+            var enemy0:Character = characterBuilder.build();
+
+            characterBuilder.setName("enemy1");
+            var enemy1:Character = characterBuilder.build();
+
+            var targets:Vector.<ITarget> = new Vector.<ITarget>();
+            targets.push(testCharacter, testCharacter2, testCharacter3, enemy0, enemy1);
+            testCharacter.otherCharacters = targets;
+            testCharacter.setSelectableTargets(Range.RELATIVE_SINGLE_ENEMY);
         }
 
     }

--- a/src/tests/charas/TestItem.as
+++ b/src/tests/charas/TestItem.as
@@ -4,6 +4,8 @@ package tests.charas {
     import app.charas.Character;
     import app.charas.CharacterBuilder;
     import tests.Assert;
+    import app.charas.ItemBuilder;
+    import app.charas.Range;
 
     public class TestItem {
         public function TestItem() {
@@ -14,6 +16,11 @@ package tests.charas {
             var owner:Character = new CharacterBuilder().build();
             var item:Item = new Item(owner, "testItemName", "");
             Assert.areEqual(item.DisplayName, "testItemName");
+
+            var itemBuilder:ItemBuilder = new ItemBuilder().setOwner(owner);
+            var testItem:Item = itemBuilder.build(0);
+            Assert.areEqual(testItem.DisplayName, "testItem0");
+            Assert.areEqual(testItem.TargetRange, Range.RELATIVE_SINGLE_ENEMY);
         }
     }
 }

--- a/src/tests/charas/TestItem.as
+++ b/src/tests/charas/TestItem.as
@@ -1,0 +1,19 @@
+package tests.charas {
+
+    import app.charas.Item;
+    import app.charas.Character;
+    import app.charas.CharacterBuilder;
+    import tests.Assert;
+
+    public class TestItem {
+        public function TestItem() {
+            test();
+        }
+
+        private function test():void {
+            var owner:Character = new CharacterBuilder().build();
+            var item:Item = new Item(owner, "testItemName", "");
+            Assert.areEqual(item.DisplayName, "testItemName");
+        }
+    }
+}

--- a/src/tests/charas/TestSkill.as
+++ b/src/tests/charas/TestSkill.as
@@ -1,0 +1,25 @@
+package tests.charas {
+
+    import app.charas.Skill;
+    import app.charas.SkillBuilder;
+    import app.charas.Character;
+    import tests.Assert;
+    import app.charas.Range;
+
+    public class TestSkill {
+        public function TestSkill() {
+            test();
+        }
+
+        private function test():void {
+            var skillBuilder:SkillBuilder = new SkillBuilder();
+            skillBuilder.setName("testSkill");
+            skillBuilder.setCost(1);
+            skillBuilder.setTargetRange(Range.RELATIVE_SINGLE_ENEMY);
+
+            var skill:Skill = skillBuilder.build();
+            Assert.areEqual(skill.DisplayName, "testSkill");
+            Assert.areEqual(skill.Cost, 1);
+        }
+    }
+}


### PR DESCRIPTION
- インターフェース追加 / IActionを追加
- クラス追加 / 戦闘中の行動を表すクラスの一つである Skill クラスを追加
- 機能追加 / Characterに実際の行動を格納するフィールドとプロパティを追加
- 機能追加 / IActionインターフェースにプロパティを追加
- 機能追加 / CharacterにITargetを実装し、インターフェースに宣言されている機能を実装
- 機能追加 / IActionに行動の対象範囲を表すプロパティを追加
- クラス追加 / アイテムを表す Item クラスを追加
- リプレイス / Assertクラスを別のプロジェクトから持ってきて置き換え
- テスト / Skill, Item のテストを追加
- クラス追加 / アイテムクラス用のビルダークラスを追加
- 機能追加 / アイテムとスキルのコマンド実行時の動作を設定
- 機能追加 / Rangeクラスに相対範囲を絶対範囲に変換するメソッドを追加
- 機能追加 / 要素数０の状態で呼び出すとエラーになっていたので修正
- update

close #5
