### PR TITLE
キャラクターのコマンドを選択を手動で完了できるよう実装

### DIFF
--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -1,6 +1,5 @@
 package app.charas {
 
-    import app.cmds.CommandsStack;
     import app.cmds.IBattleCommand;
 
     /**
@@ -10,8 +9,12 @@ package app.charas {
     public class Character implements ITarget, IBattleCommand {
         private var name:String;
         private var isFriend:Boolean = true;
-        private var commandStack:CommandsStack = new CommandsStack();
         public var otherCharacters:Vector.<ITarget>;
+        private var commandManager:CommandManager = new CommandManager();
+
+        public function get CmdManager():CommandManager {
+            return commandManager;
+        }
 
         public function get Name():String {
             return name;
@@ -52,27 +55,11 @@ package app.charas {
             return (this.Abilities.HP.Currentry > 0);
         }
 
-        public function get Commands():CommandsStack {
-            return commandStack;
-        }
-
+        /**
+         * このキャラクターが所持するIBattleCommandの中から、指定されたインデックスのコマンドを実行します。
+         * @param commandIndex
+         */
         public function executeBattleCommand(commandIndex:int):void {
-            var selectedCommand:IBattleCommand = commandStack.TopCommands[commandIndex];
-            if (selectedCommand is IAction) {
-                // Skill or Item
-                Action = IAction(selectedCommand);
-                Action.Targets = getTargetables(Action.TargetRange);
-                var battleCommands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
-                for each (var t:ITarget in Action.Targets) {
-                    battleCommands.push(IBattleCommand(t));
-                }
-            }
-
-            if (selectedCommand is ITarget) {
-                // selected target character
-
-            }
-            commandStack.TopCommands[commandIndex].executeAsBattleCommand();
         }
 
         private function getTargetables(targetableRange:String):Vector.<ITarget> {

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -12,6 +12,7 @@ package app.charas {
         private var isFriend:Boolean = true;
         public var otherCharacters:Vector.<ITarget>;
         private var commandManager:CommandManager = new CommandManager();
+        private var targets:Vector.<ITarget> = new Vector.<ITarget>();
 
         public function get CmdManager():CommandManager {
             return commandManager;
@@ -65,6 +66,27 @@ package app.charas {
          * @param commandIndex
          */
         public function executeBattleCommand(commandIndex:int):void {
+            var selectedCommand:IBattleCommand = CmdManager.TopCommands[commandIndex];
+
+            if (selectedCommand is Character) {
+                this.targets = new Vector.<ITarget>();
+                targets.push(Character(selectedCommand));
+            }
+
+            if (selectedCommand.IsFinalCommand) {
+                CmdManager.Selected = true;
+                return;
+            }
+
+            var nextCommands:Vector.<IBattleCommand> = selectedCommand.executeAsBattleCommand();
+            if (nextCommands.length != 0) {
+                CmdManager.stackCommand(nextCommands);
+            } else {
+                // 例えば、ターゲットにできるキャラクターが存在しないとか、アイテムやスキルを一つも所持していない等
+                // そういった場合に nextCommands == 0 の状態になる可能性あり。
+                // このブロックを通った場合、キャラクターの状態はこのメソッド突入時と同じ状態になるはず。
+                selectedCommand.cancel();
+            }
         }
 
         private function getTargetables(targetableRange:String):Vector.<ITarget> {

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -1,6 +1,7 @@
 package app.charas {
 
     import app.cmds.IBattleCommand;
+    import app.cmds.AttackCommand;
 
     /**
      * ...
@@ -40,6 +41,10 @@ package app.charas {
             this.name = name;
             this.abilities = ability;
             this.isFriend = isFriend;
+
+            var defaultCommands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+            defaultCommands.push(new AttackCommand(this));
+            CmdManager.DefaultCommands = defaultCommands;
         }
 
 

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -7,8 +7,7 @@ package app.charas {
      * ...
      * @author
      */
-    public class Character implements ITarget {
-
+    public class Character implements ITarget, IBattleCommand {
         private var name:String;
         private var isFriend:Boolean = true;
         private var commandStack:CommandsStack = new CommandsStack();
@@ -83,6 +82,16 @@ package app.charas {
             });
 
             return selected;
+        }
+
+        public function executeAsBattleCommand():void {
+        }
+
+        public function cancel():void {
+        }
+
+        public function get IsFinalCommand():Boolean {
+            return true;
         }
     }
 

--- a/src/app/charas/Character.as
+++ b/src/app/charas/Character.as
@@ -76,7 +76,8 @@ package app.charas {
             return selected;
         }
 
-        public function executeAsBattleCommand():void {
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
+            return new Vector.<IBattleCommand>();
         }
 
         public function cancel():void {

--- a/src/app/charas/CommandManager.as
+++ b/src/app/charas/CommandManager.as
@@ -1,0 +1,42 @@
+package app.charas {
+
+    import app.cmds.CommandsStack;
+    import app.cmds.IBattleCommand;
+
+    public class CommandManager {
+
+        private var selected:Boolean = false;
+        private var commandStack:CommandsStack = new CommandsStack();
+        private var defaultCommands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+        private var commands:Vector.<Vector.<IBattleCommand>> = new Vector.<Vector.<IBattleCommand>>();
+
+        public function CommandManager() {
+
+        }
+
+        public function get Selected():Boolean {
+            return selected;
+        }
+
+        public function set Selected(value:Boolean):void {
+            selected = value;
+        }
+
+        public function stackCommand(value:Vector.<IBattleCommand>):void {
+            commands.push(value);
+        }
+
+        public function get TopCommands():Vector.<IBattleCommand> {
+            return (commands.length > 0) ? commands[commands.length - 1] : new Vector.<IBattleCommand>();
+        }
+
+        public function set DefaultCommands(value:Vector.<IBattleCommand>):void {
+            defaultCommands = value;
+            commands.push(value);
+        }
+
+        public function get DefaultCommands():Vector.<IBattleCommand> {
+            return defaultCommands;
+        }
+    }
+}

--- a/src/app/charas/Item.as
+++ b/src/app/charas/Item.as
@@ -34,8 +34,9 @@ package app.charas {
             return displayName;
         }
 
-        public function executeAsBattleCommand():void {
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
             owner.Action = this;
+            return new Vector.<IBattleCommand>();
         }
 
         public function cancel():void {

--- a/src/app/charas/Item.as
+++ b/src/app/charas/Item.as
@@ -40,5 +40,9 @@ package app.charas {
 
         public function cancel():void {
         }
+
+        public function get IsFinalCommand():Boolean {
+            return false;
+        }
     }
 }

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -47,5 +47,9 @@ package app.charas {
         public function get TargetRange():String {
             return targetRange;
         }
+
+        public function get IsFinalCommand():Boolean {
+            return false;
+        }
     }
 }

--- a/src/app/charas/Skill.as
+++ b/src/app/charas/Skill.as
@@ -26,8 +26,9 @@ package app.charas {
             return cost;
         }
 
-        public function executeAsBattleCommand():void {
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
             owner.Action = this;
+            return new Vector.<IBattleCommand>();
         }
 
         public function cancel():void {

--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -24,10 +24,13 @@ package app.cmds {
         public function executeAsBattleCommand():void {
 
         }
-        
-        public function cancel():void{
+
+        public function cancel():void {
         }
 
-    }
 
+        public function get IsFinalCommand():Boolean {
+            return false;
+        }
+    }
 }

--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -1,6 +1,7 @@
 package app.cmds {
 
     import app.charas.Character;
+    import app.charas.ITarget;
 
     /**
      * ...
@@ -22,7 +23,14 @@ package app.cmds {
         }
 
         public function executeAsBattleCommand():Vector.<IBattleCommand> {
-            return new Vector.<IBattleCommand>()
+            var commands:Vector.<IBattleCommand> = new Vector.<IBattleCommand>();
+            owner.otherCharacters.forEach(function(item:ITarget, i:int, v:*):void {
+                if (!item.IsFriend) {
+                    commands.push(IBattleCommand(item));
+                }
+            });
+
+            return commands;
         }
 
         public function cancel():void {

--- a/src/app/cmds/AttackCommand.as
+++ b/src/app/cmds/AttackCommand.as
@@ -21,8 +21,8 @@ package app.cmds {
             return "攻撃";
         }
 
-        public function executeAsBattleCommand():void {
-
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
+            return new Vector.<IBattleCommand>()
         }
 
         public function cancel():void {

--- a/src/app/cmds/IBattleCommand.as
+++ b/src/app/cmds/IBattleCommand.as
@@ -6,7 +6,7 @@ package app.cmds {
      */
     public interface IBattleCommand {
         function get DisplayName():String;
-        function executeAsBattleCommand():void;
+        function executeAsBattleCommand():Vector.<IBattleCommand>;
         function cancel():void;
         function get IsFinalCommand():Boolean;
     }

--- a/src/app/cmds/IBattleCommand.as
+++ b/src/app/cmds/IBattleCommand.as
@@ -8,6 +8,7 @@ package app.cmds {
         function get DisplayName():String;
         function executeAsBattleCommand():void;
         function cancel():void;
+        function get IsFinalCommand():Boolean;
     }
 
 }

--- a/src/app/cmds/ItemCommand.as
+++ b/src/app/cmds/ItemCommand.as
@@ -27,6 +27,10 @@ package app.cmds {
 
         public function cancel():void {
         }
+
+        public function get IsFinalCommand():Boolean {
+            return false;
+        }
     }
 
 }

--- a/src/app/cmds/ItemCommand.as
+++ b/src/app/cmds/ItemCommand.as
@@ -21,8 +21,8 @@ package app.cmds {
             return "アイテム";
         }
 
-        public function executeAsBattleCommand():void {
-
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
+            return new Vector.<IBattleCommand>();
         }
 
         public function cancel():void {

--- a/src/app/cmds/SkillCommand.as
+++ b/src/app/cmds/SkillCommand.as
@@ -21,8 +21,8 @@ package app.cmds {
             return "スキル";
         }
 
-        public function executeAsBattleCommand():void {
-
+        public function executeAsBattleCommand():Vector.<IBattleCommand> {
+            return new Vector.<IBattleCommand>();
         }
 
         public function cancel():void {

--- a/src/app/cmds/SkillCommand.as
+++ b/src/app/cmds/SkillCommand.as
@@ -27,6 +27,10 @@ package app.cmds {
 
         public function cancel():void {
         }
+
+        public function get IsFinalCommand():Boolean {
+            return false;
+        }
     }
 
 }

--- a/src/tests/charas/TestCharacter.as
+++ b/src/tests/charas/TestCharacter.as
@@ -14,6 +14,7 @@ package tests.charas {
 
         public function TestCharacter() {
             creationTest();
+            executeBattleCommandTest();
         }
 
         private function creationTest():void {
@@ -49,6 +50,49 @@ package tests.charas {
             testCharacter.otherCharacters = targets;
         }
 
-    }
 
+        private function executeBattleCommandTest():void {
+            var ally0:Character = getTestFriendBuilder().build();
+            var enemy0:Character = getTestEnemyBuilder().build();
+            var enemy1:Character = getTestEnemyBuilder().build();
+
+            ally0.otherCharacters = new Vector.<ITarget>();
+            ally0.otherCharacters.push(enemy0);
+            ally0.otherCharacters.push(enemy1);
+
+            // 一番上の項目である "攻撃" コマンドを実行する
+            ally0.executeBattleCommand(0);
+
+            // 攻撃コマンドを実行した結果、次のコマンド項目の数は敵の数(2)の状態になり、
+            // CmdManager.Selected はまだ false つまりコマンド選択は未完了
+            Assert.areEqual(ally0.CmdManager.TopCommands.length, 2);
+            Assert.isFalse(ally0.CmdManager.Selected);
+
+            // 表示されているターゲット０番を選択すると、 Selected は true となりコマンド選択が完了状態になる。
+            ally0.executeBattleCommand(0);
+            Assert.isTrue(ally0.CmdManager.Selected);
+        }
+
+        private function getTestFriendBuilder():CharacterBuilder {
+            var characterBuilder:CharacterBuilder = new CharacterBuilder()
+            characterBuilder.setName("testFriend");
+            characterBuilder.setLevel(1);
+            characterBuilder.setHp(10);
+            characterBuilder.setSp(5);
+            characterBuilder.setAtk(3);
+            characterBuilder.setGud(3);
+            characterBuilder.setSp(2);
+            characterBuilder.setIsFriend(true);
+
+            return characterBuilder;
+        }
+
+        private function getTestEnemyBuilder():CharacterBuilder {
+            var characterBuilder:CharacterBuilder = getTestFriendBuilder();
+            characterBuilder.setName("testEnemy");
+            characterBuilder.setIsFriend(false);
+
+            return characterBuilder;
+        }
+    }
 }

--- a/src/tests/charas/TestCharacter.as
+++ b/src/tests/charas/TestCharacter.as
@@ -47,7 +47,6 @@ package tests.charas {
             var targets:Vector.<ITarget> = new Vector.<ITarget>();
             targets.push(testCharacter, testCharacter2, testCharacter3, enemy0, enemy1);
             testCharacter.otherCharacters = targets;
-            testCharacter.setSelectableTargets(Range.RELATIVE_SINGLE_ENEMY);
         }
 
     }


### PR DESCRIPTION
- 機能追加 / IBattleCommand インターフェースに、自身が終端コマンドかどうかを示すプロパティを追加
- 機能追加 / Character に IBattleCommand を実装
- クラス追加 / コマンド関連の機能をまとめたクラスを追加。
- 機能追加 / キャラクターが AttackCommand をデフォルトで持つよう変更
- 仕様変更 / IBattleCommand の executeAsBattleCommand() の仕様を変更
- 機能追加 / キャラクターのコマンド選択機能を実装

close #7
