### PR TITLE
戦闘シーンのコマンド選択パートを作成

### DIFF
--- a/src/app/scns/IScene.as
+++ b/src/app/scns/IScene.as
@@ -1,0 +1,21 @@
+package app.scns {
+
+    import flash.events.EventDispatcher;
+    import flash.events.IEventDispatcher;
+    import app.charas.Party;
+
+    public interface IScene extends IEventDispatcher {
+
+        /**
+         * シーン開始時に呼び出すメソッドです。
+         */
+        function start():void;
+
+        function getParty():Party;
+
+        /**
+         * シーン内で使用しているリソースを直ちに破棄します。
+         */
+        function dispose():void;
+    }
+}

--- a/src/app/scns/IScenePart.as
+++ b/src/app/scns/IScenePart.as
@@ -1,5 +1,7 @@
 package app.scns {
     import flash.events.IEventDispatcher;
+    import flash.events.KeyboardEvent;
+    import flash.events.MouseEvent;
 
     /** シーン内の一部分を担うクラスに実装されるインターフェースで、IScene 実装クラスによって保持されます。
      * このインターフェースを実装するクラスが処理を終了する際、flash.events.Event クラスの COMPLETE イベントを送出します。
@@ -13,9 +15,7 @@ package app.scns {
          */
         function get AllowInput():Boolean
 
-        /**
-         * @param value このシーンパーツに対して入力を行います。
-         */
-        function input(value:uint):void
+        function keyboardInput(e:KeyboardEvent):void;
+        function mouseInput(e:MouseEvent):void;
     }
 }

--- a/src/app/scns/IScenePart.as
+++ b/src/app/scns/IScenePart.as
@@ -1,0 +1,11 @@
+package app.scns {
+    import flash.events.IEventDispatcher;
+
+    /** シーン内の一部分を担うクラスに実装されるインターフェースで、IScene 実装クラスによって保持されます。
+     * このインターフェースを実装するクラスが処理を終了する際、flash.events.Event クラスの COMPLETE イベントを送出します。
+     * IScene 実装クラスは COMPLETE イベントを受け取ったら、次のパートに移行してください。
+     */
+    public interface IScenePart extends IEventDispatcher {
+        function start():void;
+    }
+}

--- a/src/app/scns/IScenePart.as
+++ b/src/app/scns/IScenePart.as
@@ -7,5 +7,15 @@ package app.scns {
      */
     public interface IScenePart extends IEventDispatcher {
         function start():void;
+
+        /**
+         * @return このシーンパーツに対して、入力（キーボード、マウス）が可能かどうかを取得します
+         */
+        function get AllowInput():Boolean
+
+        /**
+         * @param value このシーンパーツに対して入力を行います。
+         */
+        function input(value:uint):void
     }
 }

--- a/src/app/scns/battle/BattleScene.as
+++ b/src/app/scns/battle/BattleScene.as
@@ -1,0 +1,30 @@
+package app.scns.battle {
+
+    import flash.display.Sprite;
+    import flash.events.IEventDispatcher;
+    import app.scns.IScene;
+    import app.charas.Party;
+    import app.scns.IScenePart;
+
+    public class BattleScene extends Sprite implements IScene {
+
+        private var party:Party;
+        private var sceneParts:Vector.<IScenePart>;
+
+        public function BattleScene(party:Party, sceneParts:Vector.<IScenePart>) {
+            this.party = party;
+            this.sceneParts = sceneParts;
+        }
+
+        public function start():void {
+        }
+
+        public function getParty():Party {
+            return party;
+        }
+
+        public function dispose():void {
+            party = null;
+        }
+    }
+}

--- a/src/app/scns/battle/BattleScene.as
+++ b/src/app/scns/battle/BattleScene.as
@@ -5,11 +5,13 @@ package app.scns.battle {
     import app.scns.IScene;
     import app.charas.Party;
     import app.scns.IScenePart;
+    import flash.events.Event;
 
     public class BattleScene extends Sprite implements IScene {
 
         private var party:Party;
         private var sceneParts:Vector.<IScenePart>;
+        private var currentSceneIndex:int = 0;
 
         public function BattleScene(party:Party, sceneParts:Vector.<IScenePart>) {
             this.party = party;
@@ -17,6 +19,8 @@ package app.scns.battle {
         }
 
         public function start():void {
+            sceneParts[currentSceneIndex].start();
+            sceneParts[currentSceneIndex].addEventListener(Event.COMPLETE, scenePartCompleted);
         }
 
         public function getParty():Party {
@@ -25,6 +29,17 @@ package app.scns.battle {
 
         public function dispose():void {
             party = null;
+        }
+
+        private function scenePartCompleted(event:Object):void {
+            sceneParts[currentSceneIndex].removeEventListener(Event.COMPLETE, scenePartCompleted);
+            currentSceneIndex++;
+            if (currentSceneIndex >= sceneParts.length) {
+                currentSceneIndex = 0;
+            }
+
+            sceneParts[currentSceneIndex].addEventListener(Event.COMPLETE, scenePartCompleted);
+            sceneParts[currentSceneIndex].start();
         }
     }
 }

--- a/src/app/scns/battle/BattleScene.as
+++ b/src/app/scns/battle/BattleScene.as
@@ -6,6 +6,8 @@ package app.scns.battle {
     import app.charas.Party;
     import app.scns.IScenePart;
     import flash.events.Event;
+    import app.charas.Character;
+    import app.charas.ITargetSource;
 
     public class BattleScene extends Sprite implements IScene {
 
@@ -16,6 +18,10 @@ package app.scns.battle {
         public function BattleScene(party:Party, sceneParts:Vector.<IScenePart>) {
             this.party = party;
             this.sceneParts = sceneParts;
+            var p:Vector.<Character> = party.getAll();
+            p.forEach(function(c:Character, i:int, v:Vector.<Character>):void {
+                c.targetSource = ITargetSource(party);
+            });
         }
 
         public function start():void {

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -1,0 +1,23 @@
+package app.scns.battle {
+
+    import flash.display.Sprite;
+    import app.scns.IScenePart;
+    import app.scns.IScene;
+
+    public class CommandSelectionPart extends Sprite implements IScenePart {
+
+
+        private var ownerScene:IScene
+
+        /**
+         * @param ownerScene このパートを保持しているシーンを入力します。
+         * このパラメーターは、パーティーメンバーを取得する際などに参照されます。
+         */
+        public function CommandSelectionPart(ownerScene:IScene) {
+            this.ownerScene = ownerScene;
+        }
+
+        public function start():void {
+        }
+    }
+}

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -3,6 +3,9 @@ package app.scns.battle {
     import flash.display.Sprite;
     import app.scns.IScenePart;
     import app.scns.IScene;
+    import app.charas.Character;
+    import app.charas.Party;
+    import flash.events.Event;
 
     public class CommandSelectionPart extends Sprite implements IScenePart {
 
@@ -18,6 +21,27 @@ package app.scns.battle {
         }
 
         public function start():void {
+            var character:Character = getCurrentCharacter();
+            if (character == null) {
+                dispatchEvent(new Event(Event.COMPLETE));
+                return;
+            }
+        }
+
+        /**
+         * @return コマンド選択未完了のキャラクターのうち、パーティー内でインデックスが最小のキャラクターを取得します。
+         */
+        private function getCurrentCharacter():Character {
+            var chara:Character;
+            var csv:Vector.<Character> = ownerScene.getParty().getOneSide(true);
+            for each (var c:Character in csv) {
+                if (!c.CmdManager.Selected) {
+                    chara = c;
+                    break;
+                }
+            }
+
+            return chara;
         }
     }
 }

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -15,22 +15,29 @@ package app.scns.battle {
     public class CommandSelectionPart extends Sprite implements IScenePart {
 
 
-        private var ownerScene:IScene
+        private var party:Party;
         private var allowInput:Boolean = false;
+        private var currentCommands:Vector.<IBattleCommand>;
+        private var cursorIndex:Point = new Point(0, 0);
 
         /**
          * @param ownerScene このパートを保持しているシーンを入力します。
          * このパラメーターは、パーティーメンバーを取得する際などに参照されます。
          */
-        public function CommandSelectionPart(ownerScene:IScene) {
-            this.ownerScene = ownerScene;
+        public function CommandSelectionPart(party:Party) {
+            this.party = party;
         }
 
         public function start():void {
-            if (getCurrentCharacter() == null) {
-                dispatchEvent(new Event(Event.COMPLETE));
+            var character:Character = getCurrentCharacter();
+            if (character == null) {
+                complete();
                 return;
             }
+
+            currentCommands = character.CmdManager.TopCommands;
+            allowInput = true;
+            addEventListener(KeyboardEvent.KEY_DOWN, keyboardInput);
         }
 
         /**
@@ -38,7 +45,7 @@ package app.scns.battle {
          */
         private function getCurrentCharacter():Character {
             var chara:Character;
-            var csv:Vector.<Character> = ownerScene.getParty().getOneSide(true);
+            var csv:Vector.<Character> = party.getOneSide(true);
             for each (var c:Character in csv) {
                 if (!c.CmdManager.Selected) {
                     chara = c;
@@ -53,17 +60,23 @@ package app.scns.battle {
             return allowInput;
         }
 
-        public function input(value:uint):void {
-            var commandIndex:int = commandIndexConverter(value);
-            var character:Character = getCurrentCharacter();
-            character.executeBattleCommand(commandIndex);
-            if (character.CmdManager.Selected) {
-                dispatchEvent(new Event(Event.COMPLETE));
+        private function selectCommand(value:uint):void {
+            if (!AllowInput) {
+                return;
             }
+
+            var character:Character = getCurrentCharacter();
+            character.executeBattleCommand(value);
+            if (character.CmdManager.Selected) {
+                complete();
+                return;
+            }
+
+            currentCommands = character.CmdManager.TopCommands;
         }
 
         /**
-         * input によって渡ってきた uint を変換します
+         * シーンの処理が終了した際に実行します
          */
         private function complete():void {
             dispatchEvent(new Event(Event.COMPLETE));
@@ -72,8 +85,12 @@ package app.scns.battle {
         }
 
         public function keyboardInput(e:KeyboardEvent):void {
+            if (!allowInput) {
+                return;
+            }
+
             if (e.keyCode == Keyboard.ENTER) {
-                input(cursorIndex.y);
+                selectCommand(cursorIndex.y);
             }
 
             if (e.keyCode == Keyboard.DOWN) {

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -73,6 +73,7 @@ package app.scns.battle {
             }
 
             currentCommands = character.CmdManager.TopCommands;
+            cursorIndex = new Point(0, 0);
         }
 
         /**
@@ -93,11 +94,11 @@ package app.scns.battle {
                 selectCommand(cursorIndex.y);
             }
 
-            if (e.keyCode == Keyboard.DOWN) {
+            if (e.keyCode == Keyboard.DOWN && cursorIndex.y + 1 < currentCommands.length) {
                 cursorIndex.y++;
             }
 
-            if (e.keyCode == Keyboard.UP) {
+            if (e.keyCode == Keyboard.UP && cursorIndex.y > 0) {
                 cursorIndex.y--;
             }
         }

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -11,6 +11,7 @@ package app.scns.battle {
 
 
         private var ownerScene:IScene
+        private var allowInput:Boolean = false;
 
         /**
          * @param ownerScene このパートを保持しているシーンを入力します。
@@ -21,8 +22,7 @@ package app.scns.battle {
         }
 
         public function start():void {
-            var character:Character = getCurrentCharacter();
-            if (character == null) {
+            if (getCurrentCharacter() == null) {
                 dispatchEvent(new Event(Event.COMPLETE));
                 return;
             }
@@ -42,6 +42,26 @@ package app.scns.battle {
             }
 
             return chara;
+        }
+
+        public function get AllowInput():Boolean {
+            return allowInput;
+        }
+
+        public function input(value:uint):void {
+            var commandIndex:int = commandIndexConverter(value);
+            var character:Character = getCurrentCharacter();
+            character.executeBattleCommand(commandIndex);
+            if (character.CmdManager.Selected) {
+                dispatchEvent(new Event(Event.COMPLETE));
+            }
+        }
+
+        /**
+         * input によって渡ってきた uint を変換します
+         */
+        private function commandIndexConverter(value:int):int {
+            return 0;
         }
     }
 }

--- a/src/app/scns/battle/CommandSelectionPart.as
+++ b/src/app/scns/battle/CommandSelectionPart.as
@@ -6,6 +6,11 @@ package app.scns.battle {
     import app.charas.Character;
     import app.charas.Party;
     import flash.events.Event;
+    import app.cmds.IBattleCommand;
+    import flash.ui.Keyboard;
+    import flash.events.KeyboardEvent;
+    import flash.geom.Point;
+    import flash.events.MouseEvent;
 
     public class CommandSelectionPart extends Sprite implements IScenePart {
 
@@ -60,8 +65,27 @@ package app.scns.battle {
         /**
          * input によって渡ってきた uint を変換します
          */
-        private function commandIndexConverter(value:int):int {
-            return 0;
+        private function complete():void {
+            dispatchEvent(new Event(Event.COMPLETE));
+            allowInput = false;
+            removeEventListener(KeyboardEvent.KEY_DOWN, keyboardInput);
+        }
+
+        public function keyboardInput(e:KeyboardEvent):void {
+            if (e.keyCode == Keyboard.ENTER) {
+                input(cursorIndex.y);
+            }
+
+            if (e.keyCode == Keyboard.DOWN) {
+                cursorIndex.y++;
+            }
+
+            if (e.keyCode == Keyboard.UP) {
+                cursorIndex.y--;
+            }
+        }
+
+        public function mouseInput(e:MouseEvent):void {
         }
     }
 }

--- a/src/tests/Tester.as
+++ b/src/tests/Tester.as
@@ -6,6 +6,7 @@ package tests {
     import flash.desktop.NativeApplication;
     import tests.charas.TestAutoCommander;
     import tests.scns.battles.TestBattleScene;
+    import tests.scns.battles.TestCommandSelectionPart;
 
     /**
      * ...
@@ -29,6 +30,7 @@ package tests {
             new TestParty();
             new TestAutoCommander();
             new TestBattleScene();
+            new TestCommandSelectionPart();
 
             trace("[Tester]" + " " + Assert.TestCounter + " 回のテストを完了しました");
             NativeApplication.nativeApplication.exit();

--- a/src/tests/Tester.as
+++ b/src/tests/Tester.as
@@ -5,6 +5,7 @@ package tests {
     import tests.charas.TestParty;
     import flash.desktop.NativeApplication;
     import tests.charas.TestAutoCommander;
+    import tests.scns.battles.TestBattleScene;
 
     /**
      * ...
@@ -27,6 +28,7 @@ package tests {
             new TestItem();
             new TestParty();
             new TestAutoCommander();
+            new TestBattleScene();
 
             trace("[Tester]" + " " + Assert.TestCounter + " 回のテストを完了しました");
             NativeApplication.nativeApplication.exit();

--- a/src/tests/scns/battles/DummyPart.as
+++ b/src/tests/scns/battles/DummyPart.as
@@ -2,6 +2,8 @@ package tests.scns.battles {
 
     import flash.events.EventDispatcher;
     import app.scns.IScenePart;
+    import flash.events.KeyboardEvent;
+    import flash.events.MouseEvent;
 
     public class DummyPart extends EventDispatcher implements IScenePart {
 
@@ -29,6 +31,12 @@ package tests.scns.battles {
         }
 
         public function input(value:uint):void {
+        }
+
+        public function keyboardInput(e:KeyboardEvent):void {
+        }
+
+        public function mouseInput(e:MouseEvent):void {
         }
     }
 }

--- a/src/tests/scns/battles/DummyPart.as
+++ b/src/tests/scns/battles/DummyPart.as
@@ -1,0 +1,26 @@
+package tests.scns.battles {
+
+    import flash.events.EventDispatcher;
+    import app.scns.IScenePart;
+
+    public class DummyPart extends EventDispatcher implements IScenePart {
+
+        private var startedCount:int = 0
+
+        /**
+         * startメソッドを実行した回数を表します
+         * @return
+         */
+        public function get StartedCount():int {
+            return startedCount;
+        }
+
+        public function DummyPart() {
+
+        }
+
+        public function start():void {
+            startedCount++;
+        }
+    }
+}

--- a/src/tests/scns/battles/DummyPart.as
+++ b/src/tests/scns/battles/DummyPart.as
@@ -6,6 +6,7 @@ package tests.scns.battles {
     public class DummyPart extends EventDispatcher implements IScenePart {
 
         private var startedCount:int = 0
+        private var lastInputValue:uint = 0x0;
 
         /**
          * startメソッドを実行した回数を表します
@@ -21,6 +22,13 @@ package tests.scns.battles {
 
         public function start():void {
             startedCount++;
+        }
+
+        public function get AllowInput():Boolean {
+            return true;
+        }
+
+        public function input(value:uint):void {
         }
     }
 }

--- a/src/tests/scns/battles/TestBattleScene.as
+++ b/src/tests/scns/battles/TestBattleScene.as
@@ -1,0 +1,17 @@
+package tests.scns.battles {
+
+    import app.scns.IScene;
+    import app.scns.battle.BattleScene;
+    import app.charas.Party;
+    import app.scns.IScenePart;
+
+    public class TestBattleScene {
+        public function TestBattleScene() {
+            testConstructor();
+        }
+
+        private function testConstructor():void {
+            var scene:IScene = new BattleScene(new Party(), new Vector.<IScenePart>());
+        }
+    }
+}

--- a/src/tests/scns/battles/TestBattleScene.as
+++ b/src/tests/scns/battles/TestBattleScene.as
@@ -4,14 +4,51 @@ package tests.scns.battles {
     import app.scns.battle.BattleScene;
     import app.charas.Party;
     import app.scns.IScenePart;
+    import tests.Assert;
+    import flash.events.Event;
 
     public class TestBattleScene {
+
+        private var party:Party;
+        private var sceneParts:Vector.<IScenePart>;
+        private var battleScene:IScene;
+
         public function TestBattleScene() {
             testConstructor();
+            testStart();
         }
 
         private function testConstructor():void {
+            initializeFields();
             var scene:IScene = new BattleScene(new Party(), new Vector.<IScenePart>());
+        }
+
+        private function testStart():void {
+            initializeFields();
+
+            // start() を実行した後、各 DummyPart の start() 実行回数を確認する。
+            battleScene.start();
+            Assert.areEqual(DummyPart(sceneParts[0]).StartedCount, 1);
+            Assert.areEqual(DummyPart(sceneParts[1]).StartedCount, 0);
+
+            sceneParts[0].dispatchEvent(new Event(Event.COMPLETE));
+            Assert.areEqual(DummyPart(sceneParts[0]).StartedCount, 1);
+            Assert.areEqual(DummyPart(sceneParts[1]).StartedCount, 1);
+
+            // sceneParts の要素数は 2 なので、[1] の完了イベントが飛ぶと、次は[0]が実行される
+            sceneParts[1].dispatchEvent(new Event(Event.COMPLETE));
+            Assert.areEqual(DummyPart(sceneParts[0]).StartedCount, 2);
+            Assert.areEqual(DummyPart(sceneParts[1]).StartedCount, 1);
+        }
+
+        private function initializeFields():void {
+            party = new Party();
+
+            sceneParts = new Vector.<IScenePart>()
+            sceneParts.push(new DummyPart());
+            sceneParts.push(new DummyPart());
+
+            battleScene = new BattleScene(party, sceneParts);
         }
     }
 }

--- a/src/tests/scns/battles/TestCommandSelectionPart.as
+++ b/src/tests/scns/battles/TestCommandSelectionPart.as
@@ -48,6 +48,8 @@ package tests.scns.battles {
             var c2:Character = party.getAll()[1];
 
             var enterKeyEvent:KeyboardEvent = new KeyboardEvent(KeyboardEvent.KEY_DOWN, true, false, 0, Keyboard.ENTER);
+            var downKeyEvent:KeyboardEvent = new KeyboardEvent(KeyboardEvent.KEY_DOWN, true, false, 0, Keyboard.DOWN);
+            var upKeyEvent:KeyboardEvent = new KeyboardEvent(KeyboardEvent.KEY_DOWN, true, false, 0, Keyboard.UP);
 
             var commandSelected:Boolean = false;
             sp.addEventListener(Event.COMPLETE, function(e:Event):void {
@@ -78,6 +80,32 @@ package tests.scns.battles {
             // 即座に完了イベントが飛んでいるはず。
             commandSelected = false;
             sp.start();
+            Assert.isTrue(commandSelected);
+
+            commandSelected = false;
+            c1.CmdManager.reset();
+            c1.CmdManager.Selected = false;
+            sp.start();
+            Assert.isFalse(c1.CmdManager.Selected);
+            for (var i:int = 0; i < 5; i++) {
+                sp.keyboardInput(downKeyEvent);
+            }
+
+            // 過剰なカーソル移動でインデックスがはみ出さないかチェック
+            sp.keyboardInput(enterKeyEvent);
+
+            // 実行したコマンドはアイテムコマンドだが、アイテムを所持していないため、コマンドはそのまま。
+            Assert.isFalse(c1.CmdManager.Selected);
+
+            for (i = 0; i < 5; i++) {
+                sp.keyboardInput(upKeyEvent);
+            }
+
+            sp.keyboardInput(enterKeyEvent);
+            sp.keyboardInput(enterKeyEvent);
+            sp.keyboardInput(enterKeyEvent);
+
+            Assert.isTrue(c1.CmdManager.Selected);
             Assert.isTrue(commandSelected);
         }
 

--- a/src/tests/scns/battles/TestCommandSelectionPart.as
+++ b/src/tests/scns/battles/TestCommandSelectionPart.as
@@ -10,6 +10,8 @@ package tests.scns.battles {
     import app.charas.CharacterBuilder;
     import tests.Assert;
     import flash.events.Event;
+    import flash.events.KeyboardEvent;
+    import flash.ui.Keyboard;
 
     public class TestCommandSelectionPart {
 
@@ -19,6 +21,7 @@ package tests.scns.battles {
 
         public function TestCommandSelectionPart() {
             testConstructor();
+            testKeyboardInput();
         }
 
         private function testConstructor():void {
@@ -26,7 +29,7 @@ package tests.scns.battles {
 
             // 味方キャラクターのコマンド選択が完了している場合、このパートは完了イベントを飛ばす
             var commandSelectionCompleted:Boolean = false;
-            var commandSelectionPart:CommandSelectionPart = new CommandSelectionPart(scene);
+            var commandSelectionPart:CommandSelectionPart = new CommandSelectionPart(party);
             party.getAll()[0].CmdManager.Selected = true;
             party.getAll()[1].CmdManager.Selected = true;
             commandSelectionPart.addEventListener(Event.COMPLETE, function(e:Event):void {
@@ -37,6 +40,47 @@ package tests.scns.battles {
             Assert.isTrue(commandSelectionCompleted);
         }
 
+        private function testKeyboardInput():void {
+            initializeFields();
+
+            var sp:IScenePart = sceneParts[0];
+            var c1:Character = party.getAll()[0];
+            var c2:Character = party.getAll()[1];
+
+            var enterKeyEvent:KeyboardEvent = new KeyboardEvent(KeyboardEvent.KEY_DOWN, true, false, 0, Keyboard.ENTER);
+
+            var commandSelected:Boolean = false;
+            sp.addEventListener(Event.COMPLETE, function(e:Event):void {
+                commandSelected = true;
+            });
+
+            // 入力している enterKeyEvent が送出されることによって、内部でコマンドが決定される。
+            // それを２回（攻撃コマンド --> 対象選択）でコマンド選択が終了していることが期待される。
+            // allowInput の判定で入力を遮断するので、余計な回数、キーボードを連打しても問題なし。
+            sp.start();
+            Assert.isFalse(c1.CmdManager.Selected);
+            sp.keyboardInput(enterKeyEvent);
+            sp.keyboardInput(enterKeyEvent);
+            sp.keyboardInput(enterKeyEvent);
+            Assert.isTrue(c1.CmdManager.Selected);
+            Assert.isTrue(commandSelected);
+
+            commandSelected = false;
+
+            sp.start();
+            Assert.isFalse(c2.CmdManager.Selected);
+            sp.keyboardInput(enterKeyEvent);
+            sp.keyboardInput(enterKeyEvent);
+            Assert.isTrue(c2.CmdManager.Selected);
+            Assert.isTrue(commandSelected);
+
+            // 最後は start() を呼んだ時点でコマンド選択可能なキャラクターがいないため、
+            // 即座に完了イベントが飛んでいるはず。
+            commandSelected = false;
+            sp.start();
+            Assert.isTrue(commandSelected);
+        }
+
         private function initializeFields():void {
             party = new Party();
             party.push(new CharacterBuilder().setName("ally1").setIsFriend(true).build());
@@ -44,8 +88,11 @@ package tests.scns.battles {
 
             party.push(new CharacterBuilder().setName("enemy1").setIsFriend(false).build());
             party.push(new CharacterBuilder().setName("enemy2").setIsFriend(false).build());
+
             sceneParts = new Vector.<IScenePart>();
+            sceneParts.push(new CommandSelectionPart(party));
             scene = new BattleScene(party, sceneParts);
         }
+
     }
 }

--- a/src/tests/scns/battles/TestCommandSelectionPart.as
+++ b/src/tests/scns/battles/TestCommandSelectionPart.as
@@ -1,0 +1,51 @@
+package tests.scns.battles {
+
+
+    import app.scns.battle.CommandSelectionPart;
+    import app.scns.IScene;
+    import app.charas.Party;
+    import app.scns.IScenePart;
+    import app.scns.battle.BattleScene;
+    import app.charas.Character;
+    import app.charas.CharacterBuilder;
+    import tests.Assert;
+    import flash.events.Event;
+
+    public class TestCommandSelectionPart {
+
+        private var scene:IScene;
+        private var party:Party;
+        private var sceneParts:Vector.<IScenePart>;
+
+        public function TestCommandSelectionPart() {
+            testConstructor();
+        }
+
+        private function testConstructor():void {
+            initializeFields();
+
+            // 味方キャラクターのコマンド選択が完了している場合、このパートは完了イベントを飛ばす
+            var commandSelectionCompleted:Boolean = false;
+            var commandSelectionPart:CommandSelectionPart = new CommandSelectionPart(scene);
+            party.getAll()[0].CmdManager.Selected = true;
+            party.getAll()[1].CmdManager.Selected = true;
+            commandSelectionPart.addEventListener(Event.COMPLETE, function(e:Event):void {
+                commandSelectionCompleted = true;
+            });
+
+            commandSelectionPart.start();
+            Assert.isTrue(commandSelectionCompleted);
+        }
+
+        private function initializeFields():void {
+            party = new Party();
+            party.push(new CharacterBuilder().setName("ally1").setIsFriend(true).build());
+            party.push(new CharacterBuilder().setName("ally2").setIsFriend(true).build());
+
+            party.push(new CharacterBuilder().setName("enemy1").setIsFriend(false).build());
+            party.push(new CharacterBuilder().setName("enemy2").setIsFriend(false).build());
+            sceneParts = new Vector.<IScenePart>();
+            scene = new BattleScene(party, sceneParts);
+        }
+    }
+}


### PR DESCRIPTION
- クラス追加 / シーンを表すインターフェースと、戦闘シーン関連のクラスを追加
- 機能追加 / BattleScene 内で複数の IScenePart をローテーションできるところまで実装
- 機能追加 / CommandSelectionPart内で、コマンド選択未完了のキャラクターを取得するメソッドを追加
- 仕様変更 / IScenePart インターフェースに宣言を追加
- 仕様変更 / インターフェースの input をキーボード用とマウス用のものに分離
- 機能拡張 / BattleScene のコンストラクタの動作を追加
- 機能追加 / キーボード入力によって、キャラクターのコマンド選択を行えるよう実装
- 機能追加 / CommandSelectionPart にキーボードでカーソルインデックスを動かす機能を追加

close #21
